### PR TITLE
Add paths to build.zig.zon

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -414,7 +414,7 @@ pub const InitializeDiskStep = struct {
 
                 const disk_image_path = switch (builtin.os.tag) {
                     .linux => blk: {
-                        var self_pid = std.os.linux.getpid();
+                        const self_pid = std.os.linux.getpid();
                         break :blk b.fmt("/proc/{}/fd/{}", .{ self_pid, disk.handle });
                     },
 
@@ -506,7 +506,7 @@ pub const InitializeDiskStep = struct {
         const b = step.owner;
         _ = progress;
 
-        const ids = @fieldParentPtr(InitializeDiskStep, "step", step);
+        const ids: *InitializeDiskStep = @fieldParentPtr("step", step);
 
         var man = b.cache.obtain();
         defer man.deinit();

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,4 +7,10 @@
             .hash = "1220a1f050f3a67785cbe68283b252f02f72885eea80d6a9e1856b02cd66deaf1492",
         },
     },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "README.md",
+        "src",
+    },
 }


### PR DESCRIPTION
The paths field is required in the build.zig.zon file for 0.12.0.

Also any chance we can have a license listed for this project (MIT or something like that)?